### PR TITLE
Initial support for openSUSE

### DIFF
--- a/FORMULA
+++ b/FORMULA
@@ -1,5 +1,5 @@
 name: podman
-os: Debian, Ubuntu, Raspbian, RedHat, Fedora, CentOS, Amazon, Oracle, Suse, openSUSE, Gentoo, Funtoo, Arch, Manjaro, Alpine, FreeBSD, OpenBSD, Solaris, SmartOS, Windows, MacOS
+os: Debian, Ubuntu, Raspbian, RedHat, Fedora, CentOS, Amazon, Oracle, SUSE, openSUSE, Gentoo, Funtoo, Arch, Manjaro, Alpine, FreeBSD, OpenBSD, Solaris, SmartOS, Windows, MacOS
 os_family: Debian, RedHat, Suse, Gentoo, Arch, Alpine, FreeBSD, OpenBSD, Solaris, Windows, MacOS
 version: 1.0.0
 release: 1

--- a/podman/package/install.sls
+++ b/podman/package/install.sls
@@ -87,7 +87,11 @@ Podman is installed:
 Podman required packages are installed:
   pkg.installed:
     - pkgs: {{ podman.lookup.required_pkgs }}
+{%- if podman.python_install_method == "pkg" %}
+    - reload_modules: true
+{%- endif %}
 
+{%- if podman.python_install_method == "pip" %}
 Toml and Podman python libraries are installed:
   pip.installed:
     - pkgs:
@@ -103,6 +107,7 @@ Restart salt minion on installation of toml:
     - bg: true
     - onchanges:
       - Toml and Podman python libraries are installed
+{%- endif %}
 
 # those are installed by the Debian package automatically
 Podman unit files are installed:

--- a/podman/package/salt/install.sls
+++ b/podman/package/salt/install.sls
@@ -14,12 +14,14 @@ Required packages to manage podman are installed:
     - pkgs: {{ podman.lookup.salt_compat.pips | json }}
     - reload_modules: true
 
+{%- if podman.python_install_method == 'pip' %}
 Restart salt minion on installation of docker-py:
   cmd.run:
     - name: 'salt-call service.restart salt-minion'
     - bg: true
     - onchanges:
       - pip: Required packages to manage podman are installed
+{%- endif %}
 
 Podman socket is symlinked to docker socket:
   file.symlink:

--- a/podman/parameters/defaults.yaml
+++ b/podman/parameters/defaults.yaml
@@ -87,6 +87,7 @@ values:
   debian_experimental: false
   debian_unstable: false
   install_method: pkg
+  python_install_method: pip
   salt_compat: false
   service_enable: false
   version: latest

--- a/podman/parameters/os/SUSE.yaml
+++ b/podman/parameters/os/SUSE.yaml
@@ -1,0 +1,15 @@
+---
+values:
+  lookup:
+    required_pkgs:
+      - python3-podman
+      - python3-toml
+    salt_compat:
+      pips: []
+      pkgs:
+        - python3-docker
+      sockets:
+        docker: /run/docker.sock
+        podman: /run/podman/podman.sock
+  python_install_method: pkg
+...

--- a/podman/parameters/os_family/Suse.yaml
+++ b/podman/parameters/os_family/Suse.yaml
@@ -13,12 +13,5 @@
 values:
   lookup:
     pkg_manager: zypper
-    repos:
-      stable:
-        humanname: Podman stable
-        name: Podman stable
-        baseurl: https://FIXME/rpm/stable
-        key_url: https://FIXME/key.gpg
-        gpgcheck: 1
-        gpgautoimport: true
+    repos: {}
 ...

--- a/podman/post-map.jinja
+++ b/podman/post-map.jinja
@@ -31,7 +31,7 @@
     }) -%}
   {%- elif mapdata.compose.install == "podman" -%}
     {%- if mapdata.compose.podman_compose_rev %}
-      {%- set rev = '' if mapdata.compose.podman_compose_rev is boolean else '@{}'.format(mapdata.compose.podman_compose_rev) %}
+      {%- set rev = '' if mapdata.compose.podman_compose_rev is sameas true else '@{}'.format(mapdata.compose.podman_compose_rev) %}
       {%- do mapdata.update({"_compose": "git+" ~ mapdata.lookup.compose.podman.repo ~ rev}) -%}
     {%- else %}
       {%- set p = mapdata.lookup.compose.podman -%}

--- a/test/integration/default/files/_mapdata/opensuse-tumbleweed.yaml
+++ b/test/integration/default/files/_mapdata/opensuse-tumbleweed.yaml
@@ -45,16 +45,15 @@ values:
     containers:
       base: /opt/containers
     required_pkgs:
-      - git
-      - python3-pip
+      - python3-podman
+      - python3-toml
     salt_compat:
-      pips:
-        - docker
+      pips: []
       pkgs:
-        - python3-pip
+        - python3-docker
       sockets:
-        docker: /var/run/docker.sock
-        podman: /var/run/podman/podman.sock
+        docker: /run/docker.sock
+        podman: /run/podman/podman.sock
     service:
       name: podman
       path: /etc/systemd/system/{name}.service


### PR DESCRIPTION
This adds support for SUSE based distributions and ensures they use
packaged Python libraries instead of PIP.
With this patch, the formula will be usable for configuring Podman on openSUSE Tumbleweed.
On openSUSE Leap and SUSE Linux Enterprise, additional work outside
of this formula is needed, due to an incompatible version of podman-py, however basic support is added by replacing the boolean test with a variant compatible with Jinja 2.10.
Let me know if any changes are desired.