### PR TITLE
Skip unit file management for SUSE

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -50,6 +50,7 @@ lookup:
       docker: /var/run/docker.sock
       podman: /var/run/podman/podman.sock
   service:
+    install_unit_files: true
     name: podman
     path: /etc/systemd/system/{name}.service
     socket_path: /etc/systemd/system/{name}.socket

--- a/pillar.example
+++ b/pillar.example
@@ -177,6 +177,7 @@ podman:
         docker: /var/run/docker.sock
         podman: /var/run/podman/podman.sock
     service:
+      install_unit_files: true
       name: podman
       path: /etc/systemd/system/{name}.service
       socket_path: /etc/systemd/system/{name}.socket

--- a/podman/package/install.sls
+++ b/podman/package/install.sls
@@ -110,7 +110,8 @@ Restart salt minion on installation of toml:
       - Toml and Podman python libraries are installed
 {%- endif %}
 
-# those are installed by the Debian package automatically
+# those are installed by the distribution packages automatically
+{%- if podman.lookup.service.install_unit_files %}
 Podman unit files are installed:
   file.managed:
     - names:
@@ -138,6 +139,7 @@ Podman unit files are installed:
       - Podman is installed
     - context:
         podman: {{ podman | json }}
+{%- endif %}
 
 {%- if podman.compose.install %}
 {%-   if podman.compose.install == "docker" %}

--- a/podman/package/install.sls
+++ b/podman/package/install.sls
@@ -110,8 +110,9 @@ Restart salt minion on installation of toml:
       - Toml and Podman python libraries are installed
 {%- endif %}
 
-# those are installed by the distribution packages automatically
+{#- those are installed by the distribution packages automatically #}
 {%- if podman.lookup.service.install_unit_files %}
+
 Podman unit files are installed:
   file.managed:
     - names:

--- a/podman/parameters/defaults.yaml
+++ b/podman/parameters/defaults.yaml
@@ -51,6 +51,7 @@ values:
         docker: /var/run/docker.sock
         podman: /var/run/podman/podman.sock
     service:
+      install_unit_files: true
       name: podman
       path: /etc/systemd/system/{name}.service
       socket_path: /etc/systemd/system/{name}.socket

--- a/podman/parameters/os_family/Suse.yaml
+++ b/podman/parameters/os_family/Suse.yaml
@@ -14,4 +14,6 @@ values:
   lookup:
     pkg_manager: zypper
     repos: {}
+    service:
+      install_unit_files: false
 ...


### PR DESCRIPTION
The needed service and socket unit files as part of the Podman package, avoid installing Salt managed overrides for them.