### PR TITLE
Add missing endif

### DIFF
--- a/podman/package/clean.sls
+++ b/podman/package/clean.sls
@@ -53,6 +53,7 @@ Debian unstable repository is inactive:
 Debian repositories are unpinned:
   file.absent:
     - name: /etc/apt/preferences.d/99pin-unstable
+{%-   endif %}
 {%- endif %}
 
 {%- if podman.compose.install %}


### PR DESCRIPTION
Repair "Unexpected end of template" render error upon executing podman.clean.