### PR TITLE
Support user customization

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -37,7 +37,11 @@ lookup:
     seccomp: /usr/share/containers/seccomp.json
     storage: storage.conf
   containers:
+    user:
+      name: foo
     base: /opt/containers
+  user:
+    system: false
   required_pkgs:
     - git
     - python3-pip

--- a/pillar.example
+++ b/pillar.example
@@ -163,7 +163,20 @@ podman:
       seccomp: /usr/share/containers/seccomp.json
       storage: storage.conf
     containers:
+      # if "user" is empty (the default), a user and group named after the container will be managed
+      user: {}
+      # alternatively, a custom user and group to use can be specified
+      user:
+        name: autopod
+        # optional UID/GID to use if automatic allocation is not desired
+        uid: 900
+        gid: 900
+      # the base directory under which container home directories will be created
+      #   or the user home directory if "user" is not empty
       base: /opt/containers
+    user:
+      # whether users should be created as system users
+      system: false
     enablerepo: alvistack
     required_pkgs:
       - git

--- a/podman/parameters/defaults.yaml
+++ b/podman/parameters/defaults.yaml
@@ -38,7 +38,11 @@ values:
       seccomp: /usr/share/containers/seccomp.json
       storage: storage.conf
     containers:
+      user: {}
       base: /opt/containers
+    user:
+      # on Debian 11 and openSUSE subuid/subgid are added automatically for non-system users
+      system: false
     required_pkgs:
       - git
       - python3-pip


### PR DESCRIPTION
It can be desirable to run multiple containers under a single user, either for grouping multiple containers belonging to a service or for containers requiring to be run under a specific UID/GID.